### PR TITLE
Fix SVG download in Firefox 

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,9 @@
         hiddenElement.href = 'data:attachment/text,' + encodeURIComponent(contents);
         hiddenElement.target = '_blank';
         hiddenElement.download = elementId + '.svg';
+        document.body.appendChild(hiddenElement);
         hiddenElement.click();
+        document.body.removeChild(hiddenElement);
       }
 
       function print(elementId) {


### PR DESCRIPTION
The "Download SVG" buttons work in Chrome but not in Firefox. It seems that Firefox doesn't register a click if the element being clicked hasn't been inserted into the document. Maybe there are other browsers that work the same. I added a couple of lines to insert the link element before clicking and then remove it immediately afterward.