### PR TITLE
fix demo download in Firefox

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -78,7 +78,9 @@
         hiddenElement.href = 'data:attachment/text,' + encodeURIComponent(contents);
         hiddenElement.target = '_blank';
         hiddenElement.download = elementId + '.svg';
+        document.body.appendChild(hiddenElement);
         hiddenElement.click();
+        document.body.removeChild(hiddenElement);
       }
 
       function print(elementId) {

--- a/demo/upload.html
+++ b/demo/upload.html
@@ -96,7 +96,9 @@
         hiddenElement.href = 'data:attachment/text,' + encodeURIComponent(contents);
         hiddenElement.target = '_blank';
         hiddenElement.download = elementId + '.svg';
+        document.body.appendChild(hiddenElement);
         hiddenElement.click();
+        document.body.removeChild(hiddenElement);
       }
 
       function print(elementId) {


### PR DESCRIPTION
The "Download SVG" buttons work in Chrome but not in Firefox. It seems that Firefox doesn't register a click if the element being clicked hasn't been inserted into the document. Maybe there are other browsers that work the same. I added a couple of lines to insert the link element before clicking and then remove it immediately afterward.