### PR TITLE
Updates to GEDCOM parser

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -24,6 +24,11 @@ export interface JsonEvent extends DateOrRange {
   confirmed?: boolean;
 }
 
+export interface JsonImage {
+  url?: string;
+  title?: string;
+}
+
 /** Json representation of an individual. */
 export interface JsonIndi {
   id: string;
@@ -34,7 +39,8 @@ export interface JsonIndi {
   birth?: JsonEvent;
   death?: JsonEvent;
   sex?: string;
-  imageUrl?: string;
+  imageUrl?: JsonImage;
+  images?: JsonImage[];
 }
 
 /** Json representation of a family. */
@@ -108,7 +114,7 @@ class JsonIndiDetails implements IndiDetails {
     return this.json.sex || null;
   }
   getImageUrl() {
-    return this.json.imageUrl || null;
+    return this.json.imageUrl && this.json.imageUrl.url || null;
   }
 }
 

--- a/src/data.ts
+++ b/src/data.ts
@@ -25,7 +25,7 @@ export interface JsonEvent extends DateOrRange {
 }
 
 export interface JsonImage {
-  url?: string;
+  url: string;
   title?: string;
 }
 
@@ -42,8 +42,7 @@ export interface JsonIndi {
   birth?: JsonEvent;
   death?: JsonEvent;
   sex?: string;
-  mainImage?: JsonImage;
-  album?: JsonImage[];
+  images?: JsonImage[];
 }
 
 /** Json representation of a family. */
@@ -76,8 +75,7 @@ export interface IndiDetails extends Indi {
   isConfirmedDeath(): boolean;
   getSex(): string | null;
   getImageUrl(): string | null;
-  getMainImage(): JsonImage | null;
-  getAlbumImages(): JsonImage[] | null;
+  getImages(): JsonImage[] | null;
 }
 
 /** Details of a family record. */
@@ -132,13 +130,10 @@ class JsonIndiDetails implements IndiDetails {
     return this.json.sex || null;
   }
   getImageUrl() {
-    return (this.json.mainImage && this.json.mainImage.url) || null;
+    return (this.json.images && this.json.images.length > 0 && this.json.images[0].url) || null;
   }
-  getMainImage() {
-    return this.json.mainImage || null;
-  }
-  getAlbumImages() {
-    return this.json.album || null;
+  getImages() {
+    return this.json.images || null;
   }
 }
 

--- a/src/data.ts
+++ b/src/data.ts
@@ -132,7 +132,7 @@ class JsonIndiDetails implements IndiDetails {
     return this.json.sex || null;
   }
   getImageUrl() {
-    return this.json.mainImage && this.json.mainImage.url || null;
+    return (this.json.mainImage && this.json.mainImage.url) || null;
   }
   getMainImage() {
     return this.json.mainImage || null;

--- a/src/data.ts
+++ b/src/data.ts
@@ -130,7 +130,12 @@ class JsonIndiDetails implements IndiDetails {
     return this.json.sex || null;
   }
   getImageUrl() {
-    return (this.json.images && this.json.images.length > 0 && this.json.images[0].url) || null;
+    return (
+      (this.json.images &&
+        this.json.images.length > 0 &&
+        this.json.images[0].url) ||
+      null
+    );
   }
   getImages() {
     return this.json.images || null;

--- a/src/data.ts
+++ b/src/data.ts
@@ -42,8 +42,8 @@ export interface JsonIndi {
   birth?: JsonEvent;
   death?: JsonEvent;
   sex?: string;
-  imageUrl?: JsonImage;
-  images?: JsonImage[];
+  mainImage?: JsonImage;
+  album?: JsonImage[];
 }
 
 /** Json representation of a family. */
@@ -132,13 +132,13 @@ class JsonIndiDetails implements IndiDetails {
     return this.json.sex || null;
   }
   getImageUrl() {
-    return this.json.imageUrl && this.json.imageUrl.url || null;
+    return this.json.mainImage && this.json.mainImage.url || null;
   }
   getMainImage() {
-    return this.json.imageUrl || null;
+    return this.json.mainImage || null;
   }
   getAlbumImages() {
-    return this.json.images || null;
+    return this.json.album || null;
   }
 }
 

--- a/src/data.ts
+++ b/src/data.ts
@@ -20,8 +20,10 @@ export interface DateOrRange {
 }
 
 export interface JsonEvent extends DateOrRange {
+  type?: string;
   place?: string;
   confirmed?: boolean;
+  notes?: string[];
 }
 
 export interface JsonImage {
@@ -44,6 +46,7 @@ export interface JsonIndi {
   sex?: string;
   images?: JsonImage[];
   notes?: string[];
+  events?: JsonEvent[];
 }
 
 /** Json representation of a family. */
@@ -78,6 +81,7 @@ export interface IndiDetails extends Indi {
   getImageUrl(): string | null;
   getImages(): JsonImage[] | null;
   getNotes(): string[] | null;
+  getEvents(): JsonEvent[] | null;
 }
 
 /** Details of a family record. */
@@ -144,6 +148,9 @@ class JsonIndiDetails implements IndiDetails {
   }
   getNotes() {
     return this.json.notes || null;
+  }
+  getEvents() {
+    return this.json.events || null;
   }
 }
 

--- a/src/data.ts
+++ b/src/data.ts
@@ -43,6 +43,7 @@ export interface JsonIndi {
   death?: JsonEvent;
   sex?: string;
   images?: JsonImage[];
+  notes?: string[];
 }
 
 /** Json representation of a family. */
@@ -76,6 +77,7 @@ export interface IndiDetails extends Indi {
   getSex(): string | null;
   getImageUrl(): string | null;
   getImages(): JsonImage[] | null;
+  getNotes(): string[] | null;
 }
 
 /** Details of a family record. */
@@ -139,6 +141,9 @@ class JsonIndiDetails implements IndiDetails {
   }
   getImages() {
     return this.json.images || null;
+  }
+  getNotes() {
+    return this.json.notes || null;
   }
 }
 

--- a/src/data.ts
+++ b/src/data.ts
@@ -34,6 +34,7 @@ export interface JsonIndi {
   id: string;
   firstName?: string;
   lastName?: string;
+  maidenName?: string;
   famc?: string;
   fams?: string[];
   birth?: JsonEvent;

--- a/src/data.ts
+++ b/src/data.ts
@@ -37,6 +37,8 @@ export interface JsonIndi {
   maidenName?: string;
   famc?: string;
   fams?: string[];
+  numberOfChildren?: number;
+  numberOfMarriages?: number;
   birth?: JsonEvent;
   death?: JsonEvent;
   sex?: string;
@@ -63,6 +65,10 @@ export interface JsonGedcomData {
 export interface IndiDetails extends Indi {
   getFirstName(): string | null;
   getLastName(): string | null;
+  getMaidenName(): string | null;
+  getNumberOfChildren(): number | null;
+  getNumberOfMarriages(): number | null;
+  getMaidenName(): string | null;
   getBirthDate(): DateOrRange | null;
   getBirthPlace(): string | null;
   getDeathDate(): DateOrRange | null;
@@ -70,6 +76,8 @@ export interface IndiDetails extends Indi {
   isConfirmedDeath(): boolean;
   getSex(): string | null;
   getImageUrl(): string | null;
+  getMainImage(): JsonImage | null;
+  getAlbumImages(): JsonImage[] | null;
 }
 
 /** Details of a family record. */
@@ -99,6 +107,15 @@ class JsonIndiDetails implements IndiDetails {
   getBirthDate() {
     return this.json.birth || null;
   }
+  getMaidenName() {
+    return this.json.maidenName || null;
+  }
+  getNumberOfChildren() {
+    return this.json.numberOfChildren || null;
+  }
+  getNumberOfMarriages() {
+    return this.json.numberOfMarriages || null;
+  }
   getBirthPlace() {
     return (this.json.birth && this.json.birth.place) || null;
   }
@@ -116,6 +133,12 @@ class JsonIndiDetails implements IndiDetails {
   }
   getImageUrl() {
     return this.json.imageUrl && this.json.imageUrl.url || null;
+  }
+  getMainImage() {
+    return this.json.imageUrl || null;
+  }
+  getAlbumImages() {
+    return this.json.images || null;
   }
 }
 

--- a/src/gedcom.ts
+++ b/src/gedcom.ts
@@ -119,7 +119,7 @@ function createNotes(notesTag: GedcomEntry | undefined): string[] | undefined {
 
   return findTags(notesTag.tree, 'CONT')
     .filter(x => x.data)
-    .reduce((a, i) => a.concat(i.data), [notesTag.data])
+    .reduce((a, i) => a.concat(i.data), [notesTag.data]);
 }
 
 /**
@@ -133,7 +133,6 @@ function createEvent(entry: GedcomEntry | undefined): JsonEvent | undefined {
   const typeTag = findTag(entry.tree, 'TYPE');
   const dateTag = findTag(entry.tree, 'DATE');
   const placeTag = findTag(entry.tree, 'PLAC');
-  const notes = createNotes(findTag(entry.tree, 'NOTE'));
 
   const date = dateTag && dateTag.data && getDate(dateTag.data);
   const place = placeTag && placeTag.data;
@@ -144,7 +143,7 @@ function createEvent(entry: GedcomEntry | undefined): JsonEvent | undefined {
     }
     result.confirmed = true;
     result.type = typeTag ? typeTag!.data : undefined;
-    result.notes = notes;
+    result.notes = createNotes(findTag(entry.tree, 'NOTE'));
     return result;
   }
   if (entry.data && entry.data.toLowerCase() === 'y') {
@@ -187,6 +186,9 @@ function createIndi(
     const { firstName, lastName } = extractName(maiden.data);
     if (lastName) {
       indi.maidenName = lastName;
+    }
+    if (firstName && !indi.firstName) {
+      indi.firstName = firstName;
     }
   }
 

--- a/src/gedcom.ts
+++ b/src/gedcom.ts
@@ -148,16 +148,24 @@ function createIndi(
   const indi: JsonIndi = { id, fams };
 
   // Name.
-  const nameTag = findTag(entry.tree, 'NAME');
-  if (nameTag) {
+  const nameTags = findTags(entry.tree, 'NAME');
+  nameTags.forEach((nameTag: GedcomEntry) => {
     const { firstName, lastName } = extractName(nameTag.data);
-    if (firstName) {
-      indi.firstName = firstName;
+    const type = findTag(nameTag.tree, 'TYPE');
+    if (type && type.data === 'maiden') {
+      if (lastName) {
+        indi.maidenName = lastName;
+      }
     }
-    if (lastName) {
-      indi.lastName = lastName;
+    else {
+      if (firstName) {
+        indi.firstName = firstName;
+      }
+      if (lastName) {
+        indi.lastName = lastName;
+      }
     }
-  }
+  });
 
   // Sex.
   const sexTag = findTag(entry.tree, 'SEX');

--- a/src/gedcom.ts
+++ b/src/gedcom.ts
@@ -223,21 +223,21 @@ function createIndi(
     // Dereference OBJEct if needed.
     const getFileTag = (tag: GedcomEntry) => {
       const realObjeTag = tag.data ? objects.get(pointerToId(tag.data)) : tag;
-      if (!realObjeTag) return null;
+      if (!realObjeTag) return undefined;
 
       const file = findTag(realObjeTag.tree, 'FILE');
       const title = findTag(realObjeTag.tree, 'TITL');
 
-      const result: JsonImage = {
-        url: file!.data,
-      };
-      if (title) result.title = title.data;
-      return result;
+      if (!file) return undefined;
+      return {
+        url: file.data,
+        title: title && title.data,
+      } as JsonImage;
     };
 
     indi.images = objeTags
       .map(getFileTag)
-      .filter((x): x is JsonImage => x !== null);
+      .filter((x): x is JsonImage => x !== undefined);
   }
 
   // Birth date and place.
@@ -257,8 +257,8 @@ function createIndi(
 
   // Events
   indi.events = findTags(entry.tree, 'EVEN')
-                  .map(createEvent)
-                  .filter((x): x is JsonEvent => x !== null);
+    .map(createEvent)
+    .filter((x): x is JsonEvent => x !== null);
 
   return indi;
 }

--- a/src/gedcom.ts
+++ b/src/gedcom.ts
@@ -202,21 +202,14 @@ function createIndi(
       const file = findTag(realObjeTag.tree, 'FILE');
       const title = findTag(realObjeTag.tree, 'TITL');
 
-      const result: JsonImage = {};
-      if (file) result.url = file.data;
+      const result: JsonImage = {
+        url: file!.data
+      };
       if (title) result.title = title.data;
       return result;
     };
 
-    const fileTag = getFileTag(objeTags[0]);
-    if (fileTag) {
-      indi.mainImage = fileTag;
-    }
-
-    indi.album = objeTags
-      .slice(1)
-      .map(getFileTag)
-      .filter(x => x);
+    indi.images = objeTags.map(getFileTag).filter((x): x is JsonImage => x !== null);
   }
 
   // Birth date and place.

--- a/src/gedcom.ts
+++ b/src/gedcom.ts
@@ -232,6 +232,13 @@ function createIndi(
   if (death) {
     indi.death = death;
   }
+
+  // Notes.
+  const noteTag = findTag(entry.tree, 'NOTE');
+  if (noteTag) {
+    indi.notes = [noteTag.data];
+    findTags(noteTag.tree, 'CONT').filter(x => x.data).forEach(x => indi.notes!.push(x.data));
+  }
   return indi;
 }
 

--- a/src/gedcom.ts
+++ b/src/gedcom.ts
@@ -158,10 +158,10 @@ function createIndi(
         indi.maidenName = lastName;
       }
     } else {
-      if (firstName) {
+      if (firstName && !indi.firstName) {
         indi.firstName = firstName;
       }
-      if (lastName) {
+      if (lastName && !indi.lastName) {
         indi.lastName = lastName;
       }
     }

--- a/src/gedcom.ts
+++ b/src/gedcom.ts
@@ -9,7 +9,6 @@ import {
   JsonIndi,
   JsonImage,
 } from './data';
-import { interpolateInferno } from 'd3';
 
 /** Returns the first entry with the given tag or undefined if not found. */
 function findTag(tree: GedcomEntry[], tag: string): GedcomEntry | undefined {
@@ -117,12 +116,10 @@ export function getDate(gedcomDate: string): DateOrRange | undefined {
  */
 function createNotes(notesTag: GedcomEntry | undefined): string[] | undefined {
   if (!notesTag || notesTag.tag !== 'NOTE') return undefined;
-  const result = [notesTag.data];
 
-  findTags(notesTag.tree, 'CONT')
+  return findTags(notesTag.tree, 'CONT')
     .filter(x => x.data)
-    .forEach(x => result.push(x.data));
-  return result;
+    .reduce((a, i) => a.concat(i.data), [notesTag.data])
 }
 
 /**

--- a/src/gedcom.ts
+++ b/src/gedcom.ts
@@ -7,6 +7,7 @@ import {
   JsonFam,
   JsonGedcomData,
   JsonIndi,
+  JsonImage,
 } from './data';
 
 /** Returns the first entry with the given tag or undefined if not found. */
@@ -156,8 +157,7 @@ function createIndi(
       if (lastName) {
         indi.maidenName = lastName;
       }
-    }
-    else {
+    } else {
       if (firstName) {
         indi.firstName = firstName;
       }
@@ -192,30 +192,31 @@ function createIndi(
   }
 
   // Image URL.
-  var objeTags = findTags(entry.tree, 'OBJE');
+  const objeTags = findTags(entry.tree, 'OBJE');
   if (objeTags.length > 0) {
-      // Dereference OBJEct if needed.
-      const getFileTag = (tag: GedcomEntry) => {
-          var realObjeTag = tag.data
-          ? objects.get(pointerToId(tag.data))
-          : tag;
-          if (!realObjeTag) return null;
+    // Dereference OBJEct if needed.
+    const getFileTag = (tag: GedcomEntry) => {
+      const realObjeTag = tag.data ? objects.get(pointerToId(tag.data)) : tag;
+      if (!realObjeTag) return null;
 
-          const file = findTag(realObjeTag.tree, 'FILE');
-          const title = findTag(realObjeTag.tree, 'TITL');
+      const file = findTag(realObjeTag.tree, 'FILE');
+      const title = findTag(realObjeTag.tree, 'TITL');
 
-          var result: any = {};
-          if (file) result.url = file.data;          
-          if (title) result.title = title.data;
-          return result;   
-      };
-      
-      const fileTag = getFileTag(objeTags[0]);
-      if (fileTag) {
-          indi.mainImage = fileTag;
-      }
+      const result: JsonImage = {};
+      if (file) result.url = file.data;
+      if (title) result.title = title.data;
+      return result;
+    };
 
-      indi.album = objeTags.slice(1).map(getFileTag).filter(x => x);
+    const fileTag = getFileTag(objeTags[0]);
+    if (fileTag) {
+      indi.mainImage = fileTag;
+    }
+
+    indi.album = objeTags
+      .slice(1)
+      .map(getFileTag)
+      .filter(x => x);
   }
 
   // Birth date and place.

--- a/src/gedcom.ts
+++ b/src/gedcom.ts
@@ -172,16 +172,30 @@ function createIndi(
   }
 
   // Image URL.
-  const objeTag = findTag(entry.tree, 'OBJE');
-  if (objeTag) {
-    // Dereference OBJEct if needed.
-    const realObjeTag = objeTag.data
-      ? objects.get(pointerToId(objeTag.data))!
-      : objeTag;
-    const fileTag = realObjeTag && findTag(realObjeTag.tree, 'FILE');
-    if (fileTag) {
-      indi.imageUrl = fileTag.data;
-    }
+  var objeTags = findTags(entry.tree, 'OBJE');
+  if (objeTags.length > 0) {
+      // Dereference OBJEct if needed.
+      const getFileTag = (tag: GedcomEntry) => {
+          var realObjeTag = tag.data
+          ? objects.get(pointerToId(tag.data))
+          : tag;
+          if (!realObjeTag) return null;
+
+          const file = findTag(realObjeTag.tree, 'FILE');
+          const title = findTag(realObjeTag.tree, 'TITL');
+
+          var result: any = {};
+          if (file) result.url = file.data;          
+          if (title) result.title = title.data;
+          return result;   
+      };
+      
+      const fileTag = getFileTag(objeTags[0]);
+      if (fileTag) {
+          indi.imageUrl = fileTag;
+      }
+
+      indi.images = objeTags.slice(1).map(getFileTag).filter(x => x);
   }
 
   // Birth date and place.

--- a/src/gedcom.ts
+++ b/src/gedcom.ts
@@ -167,6 +167,18 @@ function createIndi(
     }
   });
 
+  // Number of children.
+  const nchiTag = findTag(entry.tree, 'NCHI');
+  if (nchiTag) {
+    indi.numberOfChildren = +nchiTag.data;
+  }
+
+  // Number of marriages.
+  const nmrTag = findTag(entry.tree, 'NMR');
+  if (nmrTag) {
+    indi.numberOfMarriages = +nmrTag.data;
+  }
+
   // Sex.
   const sexTag = findTag(entry.tree, 'SEX');
   if (sexTag) {

--- a/src/gedcom.ts
+++ b/src/gedcom.ts
@@ -212,10 +212,10 @@ function createIndi(
       
       const fileTag = getFileTag(objeTags[0]);
       if (fileTag) {
-          indi.imageUrl = fileTag;
+          indi.mainImage = fileTag;
       }
 
-      indi.images = objeTags.slice(1).map(getFileTag).filter(x => x);
+      indi.album = objeTags.slice(1).map(getFileTag).filter(x => x);
   }
 
   // Birth date and place.

--- a/tests/gedcom.spec.ts
+++ b/tests/gedcom.spec.ts
@@ -59,6 +59,31 @@ describe('GEDCOM parser', () => {
       expect(sut.indis[0].lastName).toBe('Doe');
       expect(sut.indis[0].maidenName).toBe('Smith');
     });
+    it('should parse NAME with maiden correctly', () => {
+      let gedcom = `
+      0 @I1@ INDI
+      1 NAME /Smith/
+      2 TYPE maiden
+      1 NAME John /Doe/
+      `;
+  
+      let sut = gedcomToJson(gedcom);
+      expect(sut.indis[0].firstName).toBe('John');
+      expect(sut.indis[0].lastName).toBe('Doe');
+      expect(sut.indis[0].maidenName).toBe('Smith');
+    });
+    it('should parse correctly if no main NAME', () => {
+      let gedcom = `
+      0 @I1@ INDI
+      1 NAME /Smith/
+      2 TYPE maiden
+      `;
+  
+      let sut = gedcomToJson(gedcom);
+      expect(sut.indis[0].firstName).toBeUndefined();
+      expect(sut.indis[0].lastName).toBeUndefined();
+      expect(sut.indis[0].maidenName).toBe('Smith');
+    });
   });
 
   describe('Meta', () => {

--- a/tests/gedcom.spec.ts
+++ b/tests/gedcom.spec.ts
@@ -46,6 +46,27 @@ describe('GEDCOM parser', () => {
     });
   });
 
+  describe('Meta', () => {
+    it('should parse number of children correctly', () => {
+      let gedcom = `
+      0 @I1@ INDI
+      1 NCHI 10
+      `;
+  
+      let sut = gedcomToJson(gedcom);
+      expect(sut.indis[0].numberOfChildren).toBe(10);
+    });
+    it('should parse number of marriages correctly', () => {
+      let gedcom = `
+      0 @I1@ INDI
+      1 NMR 5
+      `;
+  
+      let sut = gedcomToJson(gedcom);
+      expect(sut.indis[0].numberOfMarriages).toBe(5);
+    });
+  });
+
   describe('Images', () => {
     it('should parse a single image object correctly', () => {
       let gedcom = `

--- a/tests/gedcom.spec.ts
+++ b/tests/gedcom.spec.ts
@@ -77,7 +77,7 @@ describe('GEDCOM parser', () => {
   
       let sut = gedcomToJson(gedcom);
       expect(sut.indis.length).toBe(1);
-      expect(sut.indis[0].imageUrl!.url).toBe('person.jpg');
+      expect(sut.indis[0].mainImage!.url).toBe('person.jpg');
     });
     it('should parse a single image with title correctly', () => {
       let gedcom = `
@@ -89,8 +89,8 @@ describe('GEDCOM parser', () => {
   
       let sut = gedcomToJson(gedcom);
       expect(sut.indis.length).toBe(1);
-      expect(sut.indis[0].imageUrl!.url).toBe('person.jpg');
-      expect(sut.indis[0].imageUrl!.title).toBe('some description');
+      expect(sut.indis[0].mainImage!.url).toBe('person.jpg');
+      expect(sut.indis[0].mainImage!.title).toBe('some description');
     });
     it('should parse multiple image objects correctly', () => {
       let gedcom = `
@@ -105,12 +105,12 @@ describe('GEDCOM parser', () => {
   
       let sut = gedcomToJson(gedcom);
       expect(sut.indis.length).toBe(1);
-      expect(sut.indis[0].imageUrl!.url).toBe('main.jpg');
-      expect(sut.indis[0].imageUrl!.title).toBe('some');
+      expect(sut.indis[0].mainImage!.url).toBe('main.jpg');
+      expect(sut.indis[0].mainImage!.title).toBe('some');
   
-      expect(sut.indis[0].images!.length).toBe(1);
-      expect(sut.indis[0].images![0].url).toBe('album.jpg');
-      expect(sut.indis[0].images![0].title).toBe('description');
+      expect(sut.indis[0].album!.length).toBe(1);
+      expect(sut.indis[0].album![0].url).toBe('album.jpg');
+      expect(sut.indis[0].album![0].title).toBe('description');
     });
   });
 });

--- a/tests/gedcom.spec.ts
+++ b/tests/gedcom.spec.ts
@@ -86,6 +86,31 @@ describe('GEDCOM parser', () => {
     });
   });
 
+  describe('Notes', () => {
+    it('should parse single note correctly', () => {
+      let gedcom = `
+      0 @I1@ INDI
+      1 NOTE Hello
+      `;
+  
+      let sut = gedcomToJson(gedcom);
+      expect(sut.indis[0].notes!.length).toBe(1);
+      expect(sut.indis[0].notes![0]).toBe('Hello');
+    });
+    it('should parse single note correctly', () => {
+      let gedcom = `
+      0 @I1@ INDI
+      1 NOTE Hello
+      2 CONT World
+      `;
+  
+      let sut = gedcomToJson(gedcom);
+      expect(sut.indis[0].notes!.length).toBe(2);
+      expect(sut.indis[0].notes![0]).toBe('Hello');
+      expect(sut.indis[0].notes![1]).toBe('World');
+    });
+  });
+
   describe('Meta', () => {
     it('should parse number of children correctly', () => {
       let gedcom = `

--- a/tests/gedcom.spec.ts
+++ b/tests/gedcom.spec.ts
@@ -44,6 +44,21 @@ describe('GEDCOM parser', () => {
       expect(sut.indis[0].lastName).toBe('Doe');
       expect(sut.indis[0].maidenName).toBe('Smith');
     });
+    it('should consider the first NAME record as main', () => {
+      let gedcom = `
+      0 @I1@ INDI
+      1 NAME John /Doe/
+      1 NAME Jane /Adams/
+      1 NAME /Smith/
+      2 TYPE maiden
+      1 NAME Tony /Stark/
+      `;
+  
+      let sut = gedcomToJson(gedcom);
+      expect(sut.indis[0].firstName).toBe('John');
+      expect(sut.indis[0].lastName).toBe('Doe');
+      expect(sut.indis[0].maidenName).toBe('Smith');
+    });
   });
 
   describe('Meta', () => {

--- a/tests/gedcom.spec.ts
+++ b/tests/gedcom.spec.ts
@@ -132,6 +132,46 @@ describe('GEDCOM parser', () => {
     });
   });
 
+  describe('Events', () => {
+    it('should parse events correctly', () => {
+      let gedcom = `
+      0 @I1@ INDI
+      1 EVEN
+      2 TYPE Simple
+      2 DATE 1 Jan 1980
+      2 PLAC 131 W 3rd St, New York, NY 10012
+      2 NOTE line1
+      3 CONT line2
+      3 CONT line3
+      `;
+  
+      let sut = gedcomToJson(gedcom);
+      expect(sut.indis[0].events!.length).toBe(1);
+      expect(sut.indis[0].events![0].type).toBe('Simple');
+      expect(sut.indis[0].events![0].date!.day).toBe(1);
+      expect(sut.indis[0].events![0].date!.month).toBe(1);
+      expect(sut.indis[0].events![0].date!.year).toBe(1980);
+      expect(sut.indis[0].events![0].place).toBe('131 W 3rd St, New York, NY 10012');
+      expect(sut.indis[0].events![0].notes![0]).toBe('line1');
+      expect(sut.indis[0].events![0].notes![1]).toBe('line2');
+      expect(sut.indis[0].events![0].notes![2]).toBe('line3');
+    });
+    it('should birthday correctly', () => {
+      let gedcom = `
+      0 @I1@ INDI
+      1 BIRT
+      2 DATE 23 Sep 1926
+      2 PLAC 247 Candlewood Path, Dix Hills, NY 11746
+      `;
+  
+      let sut = gedcomToJson(gedcom);
+      expect(sut.indis[0].birth!.date!.day).toBe(23);
+      expect(sut.indis[0].birth!.date!.month).toBe(9);
+      expect(sut.indis[0].birth!.date!.year).toBe(1926);
+      expect(sut.indis[0].birth!.place).toBe('247 Candlewood Path, Dix Hills, NY 11746');
+    });
+  });
+
   describe('Images', () => {
     it('should parse multiple image objects correctly', () => {
       let gedcom = `

--- a/tests/gedcom.spec.ts
+++ b/tests/gedcom.spec.ts
@@ -68,30 +68,6 @@ describe('GEDCOM parser', () => {
   });
 
   describe('Images', () => {
-    it('should parse a single image object correctly', () => {
-      let gedcom = `
-      0 @I1@ INDI
-      1 OBJE
-      2 FILE person.jpg
-      `;
-  
-      let sut = gedcomToJson(gedcom);
-      expect(sut.indis.length).toBe(1);
-      expect(sut.indis[0].mainImage!.url).toBe('person.jpg');
-    });
-    it('should parse a single image with title correctly', () => {
-      let gedcom = `
-      0 @I1@ INDI
-      1 OBJE
-      2 FILE person.jpg
-      2 TITL some description
-      `;
-  
-      let sut = gedcomToJson(gedcom);
-      expect(sut.indis.length).toBe(1);
-      expect(sut.indis[0].mainImage!.url).toBe('person.jpg');
-      expect(sut.indis[0].mainImage!.title).toBe('some description');
-    });
     it('should parse multiple image objects correctly', () => {
       let gedcom = `
       0 @I1@ INDI
@@ -99,18 +75,18 @@ describe('GEDCOM parser', () => {
       2 FILE main.jpg
       2 TITL some
       1 OBJE
-      2 FILE album.jpg
+      2 FILE images.jpg
       2 TITL description
       `;
   
       let sut = gedcomToJson(gedcom);
       expect(sut.indis.length).toBe(1);
-      expect(sut.indis[0].mainImage!.url).toBe('main.jpg');
-      expect(sut.indis[0].mainImage!.title).toBe('some');
   
-      expect(sut.indis[0].album!.length).toBe(1);
-      expect(sut.indis[0].album![0].url).toBe('album.jpg');
-      expect(sut.indis[0].album![0].title).toBe('description');
+      expect(sut.indis[0].images!.length).toBe(2);
+      expect(sut.indis[0].images![0].url).toBe('main.jpg');
+      expect(sut.indis[0].images![0].title).toBe('some');
+      expect(sut.indis[0].images![1].url).toBe('images.jpg');
+      expect(sut.indis[0].images![1].title).toBe('description');
     });
   });
 });

--- a/tests/gedcom.spec.ts
+++ b/tests/gedcom.spec.ts
@@ -1,20 +1,95 @@
-import {getDate} from '../src/gedcom';
+import {getDate, gedcomToJson} from '../src/gedcom';
 
 
 describe('GEDCOM parser', () => {
-  it('should parse a simple date', () => {
-    expect(getDate('9 JUN 2019')).toEqual({date: {day: 9, month: 6, year: 2019}});
+  describe('date', () => {
+    it('should parse a simple date', () => {
+      expect(getDate('9 JUN 2019')).toEqual({date: {day: 9, month: 6, year: 2019}});
+    });
+    it('should parse partial dates', () => {
+      expect(getDate('2019')).toEqual({date: {year: 2019}});
+      expect(getDate('JUN 2019')).toEqual({date: {month: 6, year: 2019}});
+      expect(getDate('9 JUN')).toEqual({date: {day: 9, month: 6}});
+    });
+    it('should parse dates before year 1000', () => {
+      expect(getDate('6')).toEqual({date: {year: 6}});
+      expect(getDate('66')).toEqual({date: {year: 66}});
+      expect(getDate('966')).toEqual({date: {year: 966}});
+      expect(getDate('JUN 966')).toEqual({date: {month: 6, year: 966}});
+      expect(getDate('9 JUN 966')).toEqual({date: {day: 9, month: 6, year: 966}});
+    });
   });
-  it('should parse partial dates', () => {
-    expect(getDate('2019')).toEqual({date: {year: 2019}});
-    expect(getDate('JUN 2019')).toEqual({date: {month: 6, year: 2019}});
-    expect(getDate('9 JUN')).toEqual({date: {day: 9, month: 6}});
+
+  describe('Name', () => {
+    it('should parse name correctly', () => {
+      let gedcom = `
+      0 @I1@ INDI
+      1 NAME John /Doe/
+      `;
+  
+      let sut = gedcomToJson(gedcom);
+      expect(sut.indis[0].firstName).toBe('John');
+      expect(sut.indis[0].lastName).toBe('Doe');
+    });
+    it('should parse maiden name correctly', () => {
+      let gedcom = `
+      0 @I1@ INDI
+      1 NAME Jane /Doe/
+      1 NAME /Smith/
+      2 TYPE maiden
+      `;
+  
+      let sut = gedcomToJson(gedcom);
+      expect(sut.indis[0].firstName).toBe('Jane');
+      expect(sut.indis[0].lastName).toBe('Doe');
+      expect(sut.indis[0].maidenName).toBe('Smith');
+    });
   });
-  it('should parse dates before year 1000', () => {
-    expect(getDate('6')).toEqual({date: {year: 6}});
-    expect(getDate('66')).toEqual({date: {year: 66}});
-    expect(getDate('966')).toEqual({date: {year: 966}});
-    expect(getDate('JUN 966')).toEqual({date: {month: 6, year: 966}});
-    expect(getDate('9 JUN 966')).toEqual({date: {day: 9, month: 6, year: 966}});
+
+  describe('Images', () => {
+    it('should parse a single image object correctly', () => {
+      let gedcom = `
+      0 @I1@ INDI
+      1 OBJE
+      2 FILE person.jpg
+      `;
+  
+      let sut = gedcomToJson(gedcom);
+      expect(sut.indis.length).toBe(1);
+      expect(sut.indis[0].imageUrl!.url).toBe('person.jpg');
+    });
+    it('should parse a single image with title correctly', () => {
+      let gedcom = `
+      0 @I1@ INDI
+      1 OBJE
+      2 FILE person.jpg
+      2 TITL some description
+      `;
+  
+      let sut = gedcomToJson(gedcom);
+      expect(sut.indis.length).toBe(1);
+      expect(sut.indis[0].imageUrl!.url).toBe('person.jpg');
+      expect(sut.indis[0].imageUrl!.title).toBe('some description');
+    });
+    it('should parse multiple image objects correctly', () => {
+      let gedcom = `
+      0 @I1@ INDI
+      1 OBJE
+      2 FILE main.jpg
+      2 TITL some
+      1 OBJE
+      2 FILE album.jpg
+      2 TITL description
+      `;
+  
+      let sut = gedcomToJson(gedcom);
+      expect(sut.indis.length).toBe(1);
+      expect(sut.indis[0].imageUrl!.url).toBe('main.jpg');
+      expect(sut.indis[0].imageUrl!.title).toBe('some');
+  
+      expect(sut.indis[0].images!.length).toBe(1);
+      expect(sut.indis[0].images![0].url).toBe('album.jpg');
+      expect(sut.indis[0].images![0].title).toBe('description');
+    });
   });
 });

--- a/tests/gedcom.spec.ts
+++ b/tests/gedcom.spec.ts
@@ -72,6 +72,19 @@ describe('GEDCOM parser', () => {
       expect(sut.indis[0].lastName).toBe('Doe');
       expect(sut.indis[0].maidenName).toBe('Smith');
     });
+    it('should treat maiden first name is the main if nothing else provided', () => {
+      let gedcom = `
+      0 @I1@ INDI
+      1 NAME John /Smith/
+      2 TYPE maiden
+      1 NAME /Doe/
+      `;
+  
+      let sut = gedcomToJson(gedcom);
+      expect(sut.indis[0].firstName).toBe('John');
+      expect(sut.indis[0].lastName).toBe('Doe');
+      expect(sut.indis[0].maidenName).toBe('Smith');
+    });
     it('should parse correctly if no main NAME', () => {
       let gedcom = `
       0 @I1@ INDI


### PR DESCRIPTION
Interface extension:
1. Parsing of Maiden name
In case NAME with TYPE `maiden` is provided, it will be used to set maidenName
2. NCHI (number of children)
3. NMR (number of marriages)
4. images: an array of all images under the INDI, excluding the first (which is treated as the main image)
5. Image (string) data type was replaced with the custom structure (file + title). To avoid the breaking change, I added an additional method getMainImage()
6. Notes parser
7. General Events parser