### PR TITLE
Russian localize

### DIFF
--- a/src/date-format.ts
+++ b/src/date-format.ts
@@ -26,6 +26,14 @@ const QUALIFIERS_I18N: Map<string, Map<string, string>> = new Map([
       ['before', 'przed'],
       ['after', 'po'],
     ]),
+    'ru',
+    new Map([
+      ['cal', 'выч.'],
+      ['abt', 'ок.'],
+      ['est', 'прибл.'],
+      ['before', 'до'],
+      ['after', 'после'],
+    ]),
   ],
 ]);
 


### PR DESCRIPTION
Name format in Gramps (https://github.com/PushKK/gramps/blob/master/po/pl.po: 3361 and 11562):
user can set order value - Surname, Given and other...
As example - I use "Surname (Notpatronymic) Given Patronymic" in Gramps.
And see - "Ivanova (Petrova) Anna Petrovna".
In Topola I see (from Gedcom file) - ""Anna Petrovna Petrova Ivanova" without "()".

May be Gramps must add name format in http string?
&nf=S(N)GP - it's &nameformat="Surname (Notpatronymic) Given Patronymic".