### PR TITLE
Added originalSizeUrl to JsonImage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 node_modules
 demo/bundle.js
+.idea

--- a/src/data.ts
+++ b/src/data.ts
@@ -29,6 +29,7 @@ export interface JsonEvent extends DateOrRange {
 export interface JsonImage {
   url: string;
   title?: string;
+  originalSizeUrl?: string;
 }
 
 /** Json representation of an individual. */


### PR DESCRIPTION
Hi, I'd like to add a new optional field to JsonImage in topola API. I am going to use it in my next PR to topola-viewer for displaying photos in details panel. 

Currently when data is fetched from wikitree api, small thumbnails are used to display photos on charts. I would like to keep it like that, cuz thumbnails are perfectly fine for chart. But in details panel we have more space, and 75px thumbnail looks reaally bad. I noticed that with wikitree api I can easily grab url for original full-size photo, and save it in JsonImage so it can be used later to build gedcom file and display original photo in details panel.


