### PR TITLE
Hide empty family boxes

### DIFF
--- a/src/detailed-renderer.ts
+++ b/src/detailed-renderer.ts
@@ -565,7 +565,7 @@ export class DetailedRenderer extends CompositeRenderer implements Renderer {
     enter
       .filter((node) => {
         const detail = details.get(node.data.family!.id)!;
-        return 0 < detail.length
+        return 0 < detail.length;
       })
       .append('rect')
       .attr('class', this.getColoringClass())

--- a/src/detailed-renderer.ts
+++ b/src/detailed-renderer.ts
@@ -551,15 +551,6 @@ export class DetailedRenderer extends CompositeRenderer implements Renderer {
       );
     }
 
-    // Box.
-    enter
-      .append('rect')
-      .attr('class', this.getColoringClass())
-      .attr('rx', 5)
-      .attr('ry', 5)
-      .attr('width', (node) => node.data.family!.width!)
-      .attr('height', (node) => node.data.family!.height!);
-
     // Extract details.
     const details = new Map<string, DetailsLine[]>();
     enter.each((node) => {
@@ -569,6 +560,19 @@ export class DetailedRenderer extends CompositeRenderer implements Renderer {
       details.set(famId, detailsList);
     });
     const maxDetails = max(Array.from(details.values(), (v) => v.length))!;
+
+    // Box.
+    enter
+      .filter((node) => {
+        const detail = details.get(node.data.family!.id)!;
+        return 0 < detail.length
+      })
+      .append('rect')
+      .attr('class', this.getColoringClass())
+      .attr('rx', 5)
+      .attr('ry', 5)
+      .attr('width', (node) => node.data.family!.width!)
+      .attr('height', (node) => node.data.family!.height!);
 
     // Render details.
     for (let i = 0; i < maxDetails; ++i) {


### PR DESCRIPTION
This PR will remove the empty boxes that were rendered for families with no details.

Before:
![before](https://user-images.githubusercontent.com/5881000/215965266-5c2b014a-a430-4ad3-bfff-cd089ce21208.png)

After:
![after](https://user-images.githubusercontent.com/5881000/215965283-a9c8f4e9-f3c7-498a-91dc-980c5771ac10.png)
