### PR TITLE
Add qualifier translations in Bulgarian

### DIFF
--- a/src/date-format.ts
+++ b/src/date-format.ts
@@ -19,6 +19,16 @@ const MONTHS_EN: Map<number, string> = new Map([
 /** Translations of the GEDCOM date qualifiers. */
 const QUALIFIERS_I18N: Map<string, Map<string, string>> = new Map([
   [
+    'bg',
+    new Map([
+      ['cal', 'прибл.'],
+      ['abt', 'ок.'],
+      ['est', 'оц.'],
+      ['before', 'преди'],
+      ['after', 'след'],
+    ]),
+  ],
+  [
     'cs',
     new Map([
       ['cal', 'vypočt.'],


### PR DESCRIPTION
This pull request introduces Bulgarian equivalents for common genealogical date qualifiers. These translations will improve the clarity and accessibility of date information for Bulgarian-speaking users.

The following translations have been added:

- cal -> прибл. (приблизително)
- abt -> ок. (около)
- est -> оц. (оценен)
- before -> преди
- after -> след

These translations have been incorporated into `src/date-format.ts`.

This enhancement contributes to a more inclusive and user-friendly experience for the project's international community.