### PR TITLE
Guard ancestor parent-node lookups against a pruned family

### DIFF
--- a/src/relatives-chart.ts
+++ b/src/relatives-chart.ts
@@ -168,14 +168,20 @@ export class RelativesChart<IndiT extends Indi, FamT extends Fam>
       });
 
       if (node.data.indiParentNodeId && node.children) {
-        thisNode.data.indiParentNodeId = node.children!.find(
+        const indiParentNode = node.children.find(
           (childNode) => childNode.id === node.data.indiParentNodeId,
-        )!.data.id;
+        );
+        if (indiParentNode) {
+          thisNode.data.indiParentNodeId = indiParentNode.data.id;
+        }
       }
       if (node.data.spouseParentNodeId && node.children) {
-        thisNode.data.spouseParentNodeId = node.children!.find(
+        const spouseParentNode = node.children.find(
           (childNode) => childNode.id === node.data.spouseParentNodeId,
-        )!.data.id;
+        );
+        if (spouseParentNode) {
+          thisNode.data.spouseParentNodeId = spouseParentNode.data.id;
+        }
       }
     });
 

--- a/tests/relatives-chart.spec.ts
+++ b/tests/relatives-chart.spec.ts
@@ -58,4 +58,42 @@ describe('Relatives chart', () => {
     chart.render();
     expect(document.querySelectorAll('g.node').length).toEqual(2);
   });
+
+  // Regression test for an ancestor whose family-as-child records only
+  // children and no parents. Such a family is pruned during hierarchy
+  // construction, but the referencing ancestor node was already given an
+  // indi/spouseParentNodeId pointing at it, leaving a dangling reference.
+  // Here F5 (only child I5, no parents) is pruned while F3 keeps a real
+  // child node (F4), so the parent-node lookup in
+  // layOutAncestorDescendants() runs and finds no match. The unguarded
+  // lookup previously threw "Cannot read properties of undefined (reading
+  // 'data')". Reduced from a real exported tree.
+  it('should render when an ancestor family-as-child has no parents defined', () => {
+    const json: JsonGedcomData = {
+      indis: [
+        { id: 'I1', fams: ['F1'] },
+        { id: 'I2', famc: 'F3', fams: ['F2'] },
+        { id: 'I3', famc: 'F2', fams: ['F1'] },
+        { id: 'I4', famc: 'F4', fams: ['F3'] },
+        { id: 'I5', famc: 'F5', fams: ['F3'] },
+        { id: 'I6', fams: ['F4'] },
+      ],
+      fams: [
+        { id: 'F1', husb: 'I3', wife: 'I1' },
+        { id: 'F2', wife: 'I2', children: ['I3'] },
+        { id: 'F3', husb: 'I4', wife: 'I5', children: ['I2'] },
+        { id: 'F4', wife: 'I6', children: ['I4'] },
+        { id: 'F5', children: ['I5'] },
+      ],
+    };
+    const data = new JsonDataProvider(json);
+    const chart = new RelativesChart({
+      data,
+      startIndi: 'I1',
+      renderer: new FakeRenderer(),
+      svgSelector: 'svg',
+    });
+    chart.render();
+    expect(document.querySelectorAll('g.node').length).toEqual(4);
+  });
 });


### PR DESCRIPTION
# Guard ancestor parent-node lookups against a pruned family

## Summary

`RelativesChart.render()` throws and the entire chart fails to render for some real-world trees: any tree where, somewhere in the ancestry, a person's family-as-child records only children and no parents (a `FAM` with `CHIL` but no `HUSB`/`WIFE`). This guards the two parent-node lookups in `layOutAncestorDescendants()` so that a missing match leaves the id unset instead of dereferencing `undefined`.

## Symptom

The compiled bundle throws:

```
TypeError: Cannot read properties of undefined (reading 'data')
```

from `layOutAncestorDescendants()`, and nothing renders.

## Root cause

`layOutAncestorDescendants()` translates each ancestor node's `indiParentNodeId` / `spouseParentNodeId` from the ancestors-tree id space into the laid-out descendant id space by locating the child node with the matching id. Both lookups asserted `Array.prototype.find()` to be non-null and dereferenced `.data.id`:

```ts
thisNode.data.indiParentNodeId = node.children!.find(
  (childNode) => childNode.id === node.data.indiParentNodeId,
)!.data.id;
```

That assertion does not always hold. When a parent individual's family-as-child records only children and no parents, `AncestorChart.createHierarchy()` sets `indi`/`spouseParentNodeId` to that family's node id and pushes the family for processing — but on pop the family has neither father nor mother, so it is skipped and never stratified into a node. The referencing node is left holding a parent-node id that matches no child. `find()` returns `undefined`, the non-null assertion is erased at compile time, and the `.data` access throws.

This is an internal inconsistency rather than a behavior change: the very next pass in the same method already treats the identical lookup as nullable —

```ts
const indiParent =
  node.children &&
  node.children.find((child) => child.id === node.data.indiParentNodeId);
if (indiParent) { /* ... */ }
```

so the two passes disagreed about whether the lookup could miss.

## Fix

Compute the matched node once, drop the non-null assertion, and assign only when a match is found. A missing match correctly leaves the parent-node id unset, which the downstream layout and link-drawing code already handle (they re-derive the same `indiParent`/`spouseParent` as nullable and the chart-util anchor selection is a plain `===` comparison that falls through harmlessly).

Behavior is unchanged for every input that already rendered: the guarded branch only differs from the old code when `find()` returns `undefined`, which previously threw.

## Tests

Adds a regression test to `tests/relatives-chart.spec.ts`, reduced from a real exported tree. In the fixture, `F5` records only its child `I5` and is pruned, while `F3` keeps a real child node (`F4`) and is left referencing the now-absent `F5` — exactly the dangling-reference condition above. The test asserts the chart renders the expected four nodes (it threw before the fix).

- `npm run build` (tsc): clean
- `npm test`: 47 passing
- Screenshot tests: unaffected — no input that previously rendered changes layout.

## Optional follow-up (intentionally not in this PR)

The deeper cause is that `createHierarchy()` emits `indi`/`spouseParentNodeId` (and a `MINUS` expander) for a family-as-child that will be pruned. A follow-up could skip both when the referenced family has no father and no mother, which would additionally remove the spurious collapse control rendered on such parents. Kept out of scope here to keep this a minimal, screenshot-safe crash fix; happy to send that separately if you'd like it.