### PR TITLE
RelativesChart: show siblings when the shared family has no parents

### DIFF
--- a/src/ancestor-chart.ts
+++ b/src/ancestor-chart.ts
@@ -97,6 +97,17 @@ export class AncestorChart<IndiT extends Indi, FamT extends Fam>
           ? [fam.getMother(), fam.getFather()]
           : [fam.getFather(), fam.getMother()];
       if (!father && !mother) {
+        // A family with no parents has no ancestors to climb to. Normally it
+        // is pruned. When retainParentlessFamilies is set and the family has
+        // more than one child, keep it as a leaf so a sibling remains once the
+        // lineage child is filtered out, letting RelativesChart render the
+        // children as siblings.
+        if (
+          this.options.retainParentlessFamilies &&
+          fam.getChildren().length > 1
+        ) {
+          parents.push(entry);
+        }
         continue;
       }
       if (mother) {

--- a/src/api.ts
+++ b/src/api.ts
@@ -169,6 +169,12 @@ export interface ChartOptions {
   startFam?: string;
   // When starting with a family, make spouses swap places.
   swapStartSpouses?: boolean;
+  // Keep a family that has no parents (no husband and no wife) as a leaf node
+  // in the ancestor hierarchy instead of pruning it. This lets charts that
+  // render siblings (RelativesChart) show the children of a parentless family
+  // as siblings of one another. Only honored when the family has more than one
+  // child. Off by default; other charts are unaffected.
+  retainParentlessFamilies?: boolean;
   horizontal?: boolean;
   // Generation number of the startIndi or startFam. Used when rendering.
   baseGeneration?: number;

--- a/src/relatives-chart.ts
+++ b/src/relatives-chart.ts
@@ -243,7 +243,9 @@ export class RelativesChart<IndiT extends Indi, FamT extends Fam>
           parentData.width! / 2 -
           (parentData.indi
             ? parentData.indi.width!
-            : parentData.spouse!.width!);
+            : parentData.spouse
+              ? parentData.spouse.width!
+              : 0);
         if (data.middle) {
           parentNode.x = 0;
         } else if (!nodeData || nodeData.middle) {
@@ -301,7 +303,9 @@ export class RelativesChart<IndiT extends Indi, FamT extends Fam>
           parentData.width! / 2 -
           (parentData.indi
             ? parentData.indi.width!
-            : parentData.spouse!.width!);
+            : parentData.spouse
+              ? parentData.spouse.width!
+              : 0);
         if (data.middle) {
           parentNode.x = 0;
         } else if (!nodeData || nodeData.middle) {
@@ -330,6 +334,7 @@ export class RelativesChart<IndiT extends Indi, FamT extends Fam>
     // Don't use common id generator because these nodes will not be drawn.
     const ancestorOptions = Object.assign({}, this.options, {
       idGenerator: undefined,
+      retainParentlessFamilies: true,
     });
     const ancestorsRoot = getAncestorsTree(ancestorOptions);
 

--- a/tests/ancestor-chart.spec.ts
+++ b/tests/ancestor-chart.spec.ts
@@ -62,4 +62,55 @@ describe('Ancestor chart', () => {
     });
     chart.render();
   });
+
+  it('prunes a parentless family by default', () => {
+    const json: JsonGedcomData = {
+      fams: [{id: 'F1', children: ['I1', 'I2']}],
+      indis: [{id: 'I1', famc: 'F1'}, {id: 'I2', famc: 'F1'}],
+    };
+    const data = new JsonDataProvider(json);
+    const chart = new AncestorChart({
+      data,
+      startIndi: 'I1',
+      renderer: new FakeRenderer(),
+      svgSelector: 'svg',
+    });
+    chart.render();
+    expect(document.querySelectorAll('g.node').length).toEqual(1);
+  });
+
+  it('retains a parentless family with siblings when requested', () => {
+    const json: JsonGedcomData = {
+      fams: [{id: 'F1', children: ['I1', 'I2']}],
+      indis: [{id: 'I1', famc: 'F1'}, {id: 'I2', famc: 'F1'}],
+    };
+    const data = new JsonDataProvider(json);
+    const chart = new AncestorChart({
+      data,
+      startIndi: 'I1',
+      renderer: new FakeRenderer(),
+      svgSelector: 'svg',
+      retainParentlessFamilies: true,
+    });
+    chart.render();
+    // The start individual plus the retained (parentless) family node.
+    expect(document.querySelectorAll('g.node').length).toEqual(2);
+  });
+
+  it('still prunes a retained parentless family with a single child', () => {
+    const json: JsonGedcomData = {
+      fams: [{id: 'F1', children: ['I1']}],
+      indis: [{id: 'I1', famc: 'F1'}],
+    };
+    const data = new JsonDataProvider(json);
+    const chart = new AncestorChart({
+      data,
+      startIndi: 'I1',
+      renderer: new FakeRenderer(),
+      svgSelector: 'svg',
+      retainParentlessFamilies: true,
+    });
+    chart.render();
+    expect(document.querySelectorAll('g.node').length).toEqual(1);
+  });
 });

--- a/tests/relatives-chart.spec.ts
+++ b/tests/relatives-chart.spec.ts
@@ -96,4 +96,47 @@ describe('Relatives chart', () => {
     chart.render();
     expect(document.querySelectorAll('g.node').length).toEqual(4);
   });
+
+  it('shows siblings when their shared family has no parents', () => {
+    const json: JsonGedcomData = {
+      fams: [{ id: 'F1', children: ['I1', 'I2'] }],
+      indis: [{ id: 'I1', famc: 'F1' }, { id: 'I2', famc: 'F1' }],
+    };
+    const data = new JsonDataProvider(json);
+    const chart = new RelativesChart({
+      data,
+      startIndi: 'I1',
+      renderer: new FakeRenderer(),
+      svgSelector: 'svg',
+    });
+    chart.render();
+    // Start individual, the parentless shared family, and sibling I2.
+    expect(document.querySelectorAll('g.node').length).toEqual(3);
+  });
+
+  it('shows a parent-level sibling from a descendant start', () => {
+    // Starting from I3, climbing through I1's parentless family F1 still
+    // surfaces I1's sibling I2.
+    const json: JsonGedcomData = {
+      fams: [
+        { id: 'F1', children: ['I1', 'I2'] },
+        { id: 'F2', husb: 'I1', children: ['I3'] },
+      ],
+      indis: [
+        { id: 'I1', famc: 'F1', fams: ['F2'] },
+        { id: 'I2', famc: 'F1' },
+        { id: 'I3', famc: 'F2' },
+      ],
+    };
+    const data = new JsonDataProvider(json);
+    const chart = new RelativesChart({
+      data,
+      startIndi: 'I3',
+      renderer: new FakeRenderer(),
+      svgSelector: 'svg',
+    });
+    chart.render();
+    // I3, I1, the parentless family F1, and sibling I2.
+    expect(document.querySelectorAll('g.node').length).toEqual(4);
+  });
 });


### PR DESCRIPTION
# Problem

Fixes #121 

When two or more people are recorded as children of the same family but that family has no husband or wife (a valid GEDCOM construct for "known siblings, unknown parents"), the relatives chart doesn't show them as siblings of one another. Focusing on one child — or any of their descendants — never surfaces the others. Real-world trigger: a Gramps export where a sibling group is entered without their parents.

# Root cause

AncestorChart.createHierarchy() drops a family from the ancestor hierarchy when it has neither father nor mother (if (!father && !mother) continue;). RelativesChart renders siblings by laying out the descendants of each ancestor family, so a dropped family takes its other children (the siblings) with it. The current regression test around this only asserts that such families don't crash the chart; it doesn't render their siblings.

# Change

Adds an opt-in retainParentlessFamilies flag to ChartOptions. When set, createHierarchy() keeps a parent-less family as a leaf node provided it has more than one child (so a sibling remains after the focused lineage child is filtered out), without climbing further. RelativesChart enables the flag; all other charts are untouched and default behavior is unchanged.

Also guards two parentData.spouse!.width! dereferences in layOutAncestorDescendants() that previously assumed every ancestor node has a spouse. These are reached only for a retained parent-less node; for normal families the guard short-circuits and output is identical.

The retained node is zero-size (no husb/wife/marriage produces no box), so siblings render joined to a common point representing the unknown parents, with no stray box or link.

# Scope / compatibility

* Off by default; only RelativesChart opts in. Hourglass, ancestor, descendant, kinship, and fancy charts are byte-identical on existing data.
* The two guards change output only in the previously-pruned path.

# Tests

* should show siblings when their shared family has no parents — two siblings, parent-less family, start from one sibling → both render.
* Descendant start — starting from a child of one sibling still surfaces the other sibling.
* Existing should work with a family with no parents defined (single child) unchanged at 1 node